### PR TITLE
add svelte library (but do not integrate with astro yet)

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "svelteSortOrder": "options-scripts-markup-styles"
+}

--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "svelte-lib": "pnpm -F svelte-lib"
   },
   "devDependencies": {
-    "prettier-plugin-astro": "^0.1.2"
+    "prettier": "^2.7.1",
+    "prettier-plugin-astro": "^0.1.2",
+    "prettier-plugin-svelte": "^2.7.0"
   },
   "resolutions": {
     "vite": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -1,22 +1,37 @@
 {
   "name": "barbajoe",
   "version": "0.1.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "build": "pnpm build:react-lib && pnpm build:blog",
-    "build:blog": "pnpm -F blog build",
-    "build:react-lib": "pnpm -F react-lib build",
-    "start": "pnpm start:react-lib & pnpm start:blog",
-    "start:blog": "pnpm -F blog start",
-    "start:react-lib": "pnpm -F react-lib dev",
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "blog": "pnpm -F blog",
-    "react-lib": "pnpm -F react-lib"
-  },
-  "keywords": [],
+  "description": "A PNPM Workspace that untilizes Astro as an app and a React and Svelte component library.",
   "author": "Joe S",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Barbacoa08/barbajoe/"
+  },
+  "keywords": [
+    "astro",
+    "pnpm",
+    "react",
+    "svelte",
+    "monorepo",
+    "workspace",
+    "workspaces",
+    "component-library"
+  ],
+  "scripts": {
+    "build": "pnpm build:react-lib && pnpm build:svelte-lib && pnpm build:blog",
+    "build:blog": "pnpm -F blog build",
+    "build:react-lib": "pnpm -F react-lib build",
+    "build:svelte-lib": "pnpm -F svelte-lib build",
+    "start": "pnpm start:react-lib & pnpm start:svelte-lib & pnpm start:blog",
+    "start:blog": "pnpm -F blog start",
+    "start:react-lib": "pnpm -F react-lib dev",
+    "start:svelte-lib": "pnpm -F svelte-lib dev",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "blog": "pnpm -F blog",
+    "react-lib": "pnpm -F react-lib",
+    "svelte-lib": "pnpm -F svelte-lib"
+  },
   "devDependencies": {
     "prettier-plugin-astro": "^0.1.2"
   },

--- a/package.json
+++ b/package.json
@@ -36,8 +36,5 @@
     "prettier": "^2.7.1",
     "prettier-plugin-astro": "^0.1.2",
     "prettier-plugin-svelte": "^2.7.0"
-  },
-  "resolutions": {
-    "vite": "^3.0.0"
   }
 }

--- a/src/apps/blog/package.json
+++ b/src/apps/blog/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@barbajoe/blog",
   "version": "0.0.1",
-  "private": true,
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
@@ -18,6 +17,7 @@
     "svelte": "^3.49.0"
   },
   "dependencies": {
-    "react-lib": "workspace:*"
+    "react-lib": "workspace:*",
+    "svelte-lib": "workspace:*"
   }
 }

--- a/src/apps/blog/src/pages/index.astro
+++ b/src/apps/blog/src/pages/index.astro
@@ -10,7 +10,7 @@ import { MyButton } from "react-lib";
   <main>
     <h1>Welcome to <span class="text-gradient">Astro</span></h1>
 
-    <MyButton />
+    <MyButton client:load />
 
     <p class="instructions">
       Check out the <code>src/pages</code> directory to get started.<br />

--- a/src/packages/react-lib/package.json
+++ b/src/packages/react-lib/package.json
@@ -1,10 +1,8 @@
 {
   "name": "react-lib",
   "version": "0.1.0",
+  "bugs": "https://github.com/Barbacoa08/barbajoe/issues",
   "type": "module",
-  "files": [
-    "dist"
-  ],
   "main": "./dist/react-lib.umd.js",
   "module": "./dist/react-lib.js",
   "types": "./dist/index.d.ts",
@@ -15,6 +13,9 @@
       "require": "./dist/react-lib.umd.cjs"
     }
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "clean": "rm -rf dist",
     "dev": "vite build --watch",

--- a/src/packages/react-lib/package.json
+++ b/src/packages/react-lib/package.json
@@ -22,16 +22,18 @@
     "build": "pnpm clean && tsc && vite build",
     "preview": "vite preview"
   },
-  "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
-  },
   "devDependencies": {
     "@types/react": "^18.0.15",
     "@types/react-dom": "^18.0.6",
     "@vitejs/plugin-react": "^2.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "typescript": "^4.7.4",
     "vite": "^3.0.2",
     "vite-plugin-dts": "^1.4.0"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   }
 }

--- a/src/packages/react-lib/src/components/MyButton/MyButton.tsx
+++ b/src/packages/react-lib/src/components/MyButton/MyButton.tsx
@@ -1,5 +1,20 @@
+import { useState } from "react";
+
 import styles from "./MyButton.module.css";
 
 export const MyButton = () => {
-  return <button className={styles["fancy-btn"]}>MyButton</button>;
+  const [count, setCount] = useState(0);
+
+  return (
+    <button
+      className={styles["fancy-btn"]}
+      onClick={() => {
+        const newCount = count + 1;
+        setCount(newCount);
+        alert(`You clicked ${newCount} times`);
+      }}
+    >
+      My Button
+    </button>
+  );
 };

--- a/src/packages/svelte-lib/.gitignore
+++ b/src/packages/svelte-lib/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/src/packages/svelte-lib/.vscode/extensions.json
+++ b/src/packages/svelte-lib/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["svelte.svelte-vscode"]
+}

--- a/src/packages/svelte-lib/README.md
+++ b/src/packages/svelte-lib/README.md
@@ -1,1 +1,48 @@
-# TODO: add cool things!
+# Svelte + TS + Vite
+
+This template should help get you started developing with Svelte and TypeScript in Vite.
+
+## Recommended IDE Setup
+
+[VS Code](https://code.visualstudio.com/) + [Svelte](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode).
+
+## Need an official Svelte framework?
+
+Check out [SvelteKit](https://github.com/sveltejs/kit#readme), which is also powered by Vite. Deploy anywhere with its serverless-first approach and adapt to various platforms, with out of the box support for TypeScript, SCSS, and Less, and easily-added support for mdsvex, GraphQL, PostCSS, Tailwind CSS, and more.
+
+## Technical considerations
+
+**Why use this over SvelteKit?**
+
+- It brings its own routing solution which might not be preferable for some users.
+- It is first and foremost a framework that just happens to use Vite under the hood, not a Vite app.
+  `vite dev` and `vite build` wouldn't work in a SvelteKit environment, for example.
+
+This template contains as little as possible to get started with Vite + TypeScript + Svelte, while taking into account the developer experience with regards to HMR and intellisense. It demonstrates capabilities on par with the other `create-vite` templates and is a good starting point for beginners dipping their toes into a Vite + Svelte project.
+
+Should you later need the extended capabilities and extensibility provided by SvelteKit, the template has been structured similarly to SvelteKit so that it is easy to migrate.
+
+**Why `global.d.ts` instead of `compilerOptions.types` inside `jsconfig.json` or `tsconfig.json`?**
+
+Setting `compilerOptions.types` shuts out all other types not explicitly listed in the configuration. Using triple-slash references keeps the default TypeScript setting of accepting type information from the entire workspace, while also adding `svelte` and `vite/client` type information.
+
+**Why include `.vscode/extensions.json`?**
+
+Other templates indirectly recommend extensions via the README, but this file allows VS Code to prompt the user to install the recommended extension upon opening the project.
+
+**Why enable `allowJs` in the TS template?**
+
+While `allowJs: false` would indeed prevent the use of `.js` files in the project, it does not prevent the use of JavaScript syntax in `.svelte` files. In addition, it would force `checkJs: false`, bringing the worst of both worlds: not being able to guarantee the entire codebase is TypeScript, and also having worse typechecking for the existing JavaScript. In addition, there are valid use cases in which a mixed codebase may be relevant.
+
+**Why is HMR not preserving my local component state?**
+
+HMR state preservation comes with a number of gotchas! It has been disabled by default in both `svelte-hmr` and `@sveltejs/vite-plugin-svelte` due to its often surprising behavior. You can read the details [here](https://github.com/rixo/svelte-hmr#svelte-hmr).
+
+If you have state that's important to retain within a component, consider creating an external store which would not be replaced by HMR.
+
+```ts
+// store.ts
+// An extremely simple external store
+import { writable } from 'svelte/store'
+export default writable(0)
+```

--- a/src/packages/svelte-lib/package.json
+++ b/src/packages/svelte-lib/package.json
@@ -20,7 +20,6 @@
     "clean": "rm -rf dist",
     "dev": "vite build --watch",
     "build": "pnpm clean && vite build",
-    "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.json"
   },
   "devDependencies": {

--- a/src/packages/svelte-lib/package.json
+++ b/src/packages/svelte-lib/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "svelte-lib",
+  "version": "0.1.0",
+  "bugs": "https://github.com/Barbacoa08/barbajoe/issues",
+  "type": "module",
+  "main": "./dist/svelte-lib.umd.js",
+  "module": "./dist/svelte-lib.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./svelte-lib.css": "./dist/svelte-lib.css",
+    ".": {
+      "import": "./dist/svelte-lib.js",
+      "require": "./dist/svelte-lib.umd.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "dev": "vite build --watch",
+    "build": "pnpm clean && vite build",
+    "preview": "vite preview",
+    "check": "svelte-check --tsconfig ./tsconfig.json"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^1.0.1",
+    "@tsconfig/svelte": "^3.0.0",
+    "svelte": "^3.49.0",
+    "svelte-check": "^2.8.0",
+    "svelte-preprocess": "^4.10.7",
+    "tslib": "^2.4.0",
+    "typescript": "^4.6.4",
+    "vite": "^3.0.0"
+  }
+}

--- a/src/packages/svelte-lib/package.json
+++ b/src/packages/svelte-lib/package.json
@@ -30,7 +30,7 @@
     "svelte-check": "^2.8.0",
     "svelte-preprocess": "^4.10.7",
     "tslib": "^2.4.0",
-    "typescript": "^4.6.4",
-    "vite": "^3.0.0"
+    "typescript": "^4.7.4",
+    "vite": "^3.0.2"
   }
 }

--- a/src/packages/svelte-lib/src/components/Counter/Counter.svelte
+++ b/src/packages/svelte-lib/src/components/Counter/Counter.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  let count: number = 0;
+  const increment = () => {
+    count += 1;
+  };
+</script>
+
+<button class="fancy-btn" on:click={increment}>
+  count is {count}
+</button>
+
+<style module>
+  .fancy-btn {
+    border-radius: 8px;
+    border: 1px solid transparent;
+    padding: 0.6em 1.2em;
+    font-size: 1em;
+    font-weight: 500;
+    font-family: inherit;
+    background-color: #1a1a1a;
+    cursor: pointer;
+    transition: border-color 0.25s;
+  }
+  .fancy-btn:hover {
+    border-color: #646cff;
+  }
+  .fancy-btn:focus,
+  .fancy-btn:focus-visible {
+    outline: 4px auto -webkit-focus-ring-color;
+  }
+</style>

--- a/src/packages/svelte-lib/src/components/Counter/index.ts
+++ b/src/packages/svelte-lib/src/components/Counter/index.ts
@@ -1,0 +1,2 @@
+import Counter from "./Counter.svelte";
+export { Counter };

--- a/src/packages/svelte-lib/src/components/index.ts
+++ b/src/packages/svelte-lib/src/components/index.ts
@@ -1,0 +1,1 @@
+export * from "./Counter";

--- a/src/packages/svelte-lib/src/main.ts
+++ b/src/packages/svelte-lib/src/main.ts
@@ -1,0 +1,1 @@
+export * from "./components";

--- a/src/packages/svelte-lib/src/vite-env.d.ts
+++ b/src/packages/svelte-lib/src/vite-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="svelte" />
+/// <reference types="vite/client" />

--- a/src/packages/svelte-lib/svelte.config.js
+++ b/src/packages/svelte-lib/svelte.config.js
@@ -1,0 +1,7 @@
+import sveltePreprocess from 'svelte-preprocess'
+
+export default {
+  // Consult https://github.com/sveltejs/svelte-preprocess
+  // for more information about preprocessors
+  preprocess: sveltePreprocess()
+}

--- a/src/packages/svelte-lib/tsconfig.json
+++ b/src/packages/svelte-lib/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "extends": "@tsconfig/svelte/tsconfig.json",
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "resolveJsonModule": true,
+    /**
+     * Typecheck JS in `.svelte` and `.js` files by default.
+     * Disable checkJs if you'd like to use dynamic types in JS.
+     * Note that setting allowJs false does not prevent the use
+     * of JS in `.svelte` files.
+     */
+    "allowJs": true,
+    "checkJs": true,
+    "isolatedModules": true
+  },
+  "include": [
+    "src/**/*.d.ts",
+    "src/**/*.ts",
+    "src/**/*.js",
+    "src/**/*.svelte"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ]
+}

--- a/src/packages/svelte-lib/tsconfig.json
+++ b/src/packages/svelte-lib/tsconfig.json
@@ -5,20 +5,13 @@
     "useDefineForClassFields": true,
     "module": "ESNext",
     "resolveJsonModule": true,
-    /**
-     * Typecheck JS in `.svelte` and `.js` files by default.
-     * Disable checkJs if you'd like to use dynamic types in JS.
-     * Note that setting allowJs false does not prevent the use
-     * of JS in `.svelte` files.
-     */
-    "allowJs": true,
-    "checkJs": true,
+    "allowJs": false,
+    "checkJs": false,
     "isolatedModules": true
   },
   "include": [
     "src/**/*.d.ts",
     "src/**/*.ts",
-    "src/**/*.js",
     "src/**/*.svelte"
   ],
   "references": [

--- a/src/packages/svelte-lib/tsconfig.node.json
+++ b/src/packages/svelte-lib/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node"
+  },
+  "include": [
+    "vite.config.ts"
+  ]
+}

--- a/src/packages/svelte-lib/vite.config.ts
+++ b/src/packages/svelte-lib/vite.config.ts
@@ -1,0 +1,22 @@
+import { resolve } from "path";
+import { defineConfig } from "vite";
+import { svelte } from "@sveltejs/vite-plugin-svelte";
+
+export default defineConfig({
+  plugins: [svelte()],
+  build: {
+    lib: {
+      entry: resolve(__dirname, "src/main.ts"),
+      name: "svelte-lib",
+      fileName: "svelte-lib",
+    },
+    rollupOptions: {
+      output: {
+        assetFileNames: (assetInfo) => {
+          if (assetInfo.name == "style.css") return "svelte-lib.css";
+          return assetInfo.name;
+        },
+      },
+    },
+  },
+});


### PR DESCRIPTION
Doesn't work with astro due to `@sveltejs/vite-plugin-svelte` using vite v2. But, the issue has been fixed in `main`, so as soon as `v1.0.2` is released, we're good. 

NOTE: issue was fixed [in this PR](https://github.com/sveltejs/vite-plugin-svelte/commit/925c3b2fbd422e1b5d528a4c7cfb4fe8a8efae66)