### PR TITLE
increase form gap, defend dialog preferences, bump version

### DIFF
--- a/src/packages/css-lib/lib/dialog.css
+++ b/src/packages/css-lib/lib/dialog.css
@@ -4,6 +4,7 @@ dialog {
   border-radius: 0.2em;
   border: none;
   padding: 0;
+  text-align: left;
 }
 dialog::backdrop {
   background: rgba(0, 0, 0, 0.3);

--- a/src/packages/css-lib/lib/form-elements.css
+++ b/src/packages/css-lib/lib/form-elements.css
@@ -2,7 +2,7 @@ form {
   margin-top: 1rem;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 1rem;
 
   & input[type="text"],
   & input[type="password"],

--- a/src/packages/css-lib/package.json
+++ b/src/packages/css-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barbajoe/css-lib",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "license": "MIT",
   "author": "Barbacoa08",
   "repository": "https://github.com/Barbacoa08/barbajoe/tree/main/src/packages/css-lib",


### PR DESCRIPTION
the defensive `text-align` is due to the fact that we can have modals live in table action buttons, as in thepp's table edit/delete modals
